### PR TITLE
feat: add browser interface for statements

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <title>Создание выписки</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.25/dist/jspdf.plugin.autotable.min.js"></script>
+</head>
+<body>
+  <h1>Создание выписки</h1>
+  <form id="statement-form">
+    <div class="field">
+      <label for="fio">ФИО</label>
+      <input id="fio" type="text" required>
+    </div>
+    <div class="field">
+      <label for="account">Счёт</label>
+      <input id="account" type="text" required>
+    </div>
+    <div class="field">
+      <label for="start-date">Дата начала</label>
+      <input id="start-date" type="date" required>
+    </div>
+    <div class="field">
+      <label for="end-date">Дата окончания</label>
+      <input id="end-date" type="date" required>
+    </div>
+    <h2>Операции</h2>
+    <table id="operations-table">
+      <thead>
+        <tr>
+          <th>Дата</th>
+          <th>Описание</th>
+          <th>Сумма</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <button type="button" id="add-operation">Добавить операцию</button>
+    <button type="button" id="download">Скачать PDF</button>
+  </form>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,59 @@
+document.addEventListener('DOMContentLoaded', () => {
+  addOperationRow();
+
+  document.getElementById('add-operation').addEventListener('click', addOperationRow);
+  document.getElementById('download').addEventListener('click', downloadPdf);
+});
+
+function addOperationRow() {
+  const tbody = document.querySelector('#operations-table tbody');
+  const row = document.createElement('tr');
+  row.innerHTML = `
+    <td><input type="date" class="op-date" required></td>
+    <td><input type="text" class="op-desc" required></td>
+    <td><input type="number" step="0.01" class="op-amount" required></td>
+    <td><button type="button" class="remove">✕</button></td>
+  `;
+  row.querySelector('.remove').addEventListener('click', () => row.remove());
+  tbody.appendChild(row);
+}
+
+function downloadPdf() {
+  const fio = document.getElementById('fio').value.trim();
+  const account = document.getElementById('account').value.trim();
+  const start = document.getElementById('start-date').value;
+  const end = document.getElementById('end-date').value;
+
+  const operations = Array.from(document.querySelectorAll('#operations-table tbody tr')).map(row => ({
+    date: row.querySelector('.op-date').value,
+    desc: row.querySelector('.op-desc').value,
+    amount: row.querySelector('.op-amount').value
+  })).filter(op => op.date || op.desc || op.amount);
+
+  const { jsPDF } = window.jspdf;
+  const doc = new jsPDF();
+  let y = 15;
+  doc.setFontSize(16);
+  doc.text('Выписка по счёту', 14, y);
+  y += 10;
+  doc.setFontSize(12);
+  doc.text(`ФИО: ${fio}`, 14, y);
+  y += 6;
+  doc.text(`Счёт: ${account}`, 14, y);
+  y += 6;
+  doc.text(`Период: ${start} — ${end}`, 14, y);
+  y += 10;
+
+  const rows = operations.map(op => [op.date, op.desc, op.amount]);
+  doc.autoTable({
+    head: [['Дата', 'Описание', 'Сумма']],
+    body: rows,
+    startY: y
+  });
+
+  const finalY = doc.lastAutoTable ? doc.lastAutoTable.finalY : y;
+  const total = operations.reduce((sum, op) => sum + parseFloat(op.amount || 0), 0);
+  doc.text(`Итого: ${total.toFixed(2)}`, 14, finalY + 10);
+
+  doc.save('statement.pdf');
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,36 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+  max-width: 800px;
+}
+
+.field {
+  margin-bottom: 10px;
+}
+
+label {
+  display: inline-block;
+  width: 120px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 10px;
+}
+
+th, td {
+  border: 1px solid #ccc;
+  padding: 6px;
+  text-align: left;
+}
+
+button {
+  padding: 6px 12px;
+  margin-right: 5px;
+  cursor: pointer;
+}
+
+button.remove {
+  padding: 2px 6px;
+}


### PR DESCRIPTION
## Summary
- add web page to enter account holder, period, and operations
- allow downloading a PDF statement generated in the browser
- style page with a simple responsive layout

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c5c8d7dec832ea42d05d98e57020e