### PR TITLE
Add web interface for manual statement creation

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,64 @@
+function addOperationRow() {
+  const tbody = document.querySelector('#opsTable tbody');
+  const tr = document.createElement('tr');
+  tr.innerHTML = `
+    <td><input type="date" class="form-control" required></td>
+    <td><input type="text" class="form-control" placeholder="Контрагент"></td>
+    <td><input type="text" class="form-control" placeholder="Описание" required></td>
+    <td><input type="number" step="0.01" class="form-control" placeholder="0.00" required></td>
+    <td><button type="button" class="btn btn-outline-danger btn-sm remove-op">×</button></td>
+  `;
+  tbody.appendChild(tr);
+}
+
+document.getElementById('addOp').addEventListener('click', addOperationRow);
+
+document.getElementById('opsTable').addEventListener('click', function(e) {
+  if (e.target.classList.contains('remove-op')) {
+    e.target.closest('tr').remove();
+  }
+});
+
+addOperationRow();
+
+document.getElementById('statementForm').addEventListener('submit', async function(e) {
+  e.preventDefault();
+  const ops = [];
+  document.querySelectorAll('#opsTable tbody tr').forEach(row => {
+    const inputs = row.querySelectorAll('input');
+    const [date, counterparty, desc, amount] = inputs;
+    if (date.value && desc.value && amount.value) {
+      ops.push({
+        date: date.value,
+        counterparty: counterparty.value,
+        description: desc.value,
+        amount: parseFloat(amount.value)
+      });
+    }
+  });
+  const payload = {
+    fio: document.getElementById('fio').value,
+    account: document.getElementById('account').value,
+    from: document.getElementById('start').value,
+    to: document.getElementById('end').value,
+    operations: ops
+  };
+  const resp = await fetch('/statement/custom', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!resp.ok) {
+    alert('Ошибка при генерации выписки');
+    return;
+  }
+  const blob = await resp.blob();
+  const url = window.URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'statement.pdf';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  window.URL.revokeObjectURL(url);
+});

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <title>Генератор выписок</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCm5ALe58JkUFffYpSvHU5awsuZVVFIhv" crossorigin="anonymous">
+</head>
+<body>
+<div class="container my-4">
+  <h1 class="mb-4">Создание выписки</h1>
+  <form id="statementForm">
+    <div class="mb-3">
+      <label for="fio" class="form-label">ФИО</label>
+      <input type="text" class="form-control" id="fio" required>
+    </div>
+    <div class="mb-3">
+      <label for="account" class="form-label">Номер счёта</label>
+      <input type="text" class="form-control" id="account" required>
+    </div>
+    <div class="row g-3">
+      <div class="col-md-6">
+        <label for="start" class="form-label">Дата начала</label>
+        <input type="date" class="form-control" id="start" required>
+      </div>
+      <div class="col-md-6">
+        <label for="end" class="form-label">Дата окончания</label>
+        <input type="date" class="form-control" id="end" required>
+      </div>
+    </div>
+    <h3 class="mt-4">Операции</h3>
+    <table class="table" id="opsTable">
+      <thead>
+        <tr>
+          <th>Дата</th>
+          <th>Плательщик/Получатель</th>
+          <th>Описание</th>
+          <th>Сумма</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <button type="button" class="btn btn-secondary mb-3" id="addOp">Добавить операцию</button>
+    <div>
+      <button type="submit" class="btn btn-primary">Скачать PDF</button>
+    </div>
+  </form>
+</div>
+<script src="{{ url_for('static', filename='app.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add browser form to input client data and operations and download PDF statements
- Implement JS to manage operations list and send request for PDF generation
- Support manual statement generation in Flask backend

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688c5f03ba0c832eaf1599c3645c2efb