### PR TITLE
feat: add prototype UI for statements

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -1,0 +1,212 @@
+(function () {
+  const dashboard = document.getElementById('dashboard');
+  const editor = document.getElementById('editor');
+  const statementsBody = document.querySelector('#statementsTable tbody');
+  const newBtn = document.getElementById('newStatementBtn');
+  const backBtn = document.getElementById('backToDashboard');
+  const addOpBtn = document.getElementById('addOperation');
+  const saveBtn = document.getElementById('saveDraft');
+  const pdfBtn = document.getElementById('generatePdf');
+  const saveStatus = document.getElementById('saveStatus');
+
+  const accountInput = document.getElementById('accountInput');
+  const ownerInput = document.getElementById('ownerInput');
+  const startInput = document.getElementById('periodStart');
+  const endInput = document.getElementById('periodEnd');
+  const openingInput = document.getElementById('openingBalance');
+  const incomingEl = document.getElementById('totalIncoming');
+  const outgoingEl = document.getElementById('totalOutgoing');
+  const closingEl = document.getElementById('closingBalance');
+  const opsBody = document.querySelector('#operationsTable tbody');
+  const searchInput = document.getElementById('searchInput');
+
+  let saveTimeout = null;
+
+  function showDashboard() {
+    editor.classList.add('d-none');
+    dashboard.classList.remove('d-none');
+    refreshStatements();
+  }
+
+  function showEditor() {
+    dashboard.classList.add('d-none');
+    editor.classList.remove('d-none');
+    loadDraft();
+    updateTotals();
+  }
+
+  newBtn.addEventListener('click', showEditor);
+  backBtn.addEventListener('click', showDashboard);
+
+  searchInput.addEventListener('input', () => {
+    const q = searchInput.value.toLowerCase();
+    Array.from(statementsBody.querySelectorAll('tr')).forEach(tr => {
+      tr.style.display = tr.textContent.toLowerCase().includes(q) ? '' : 'none';
+    });
+  });
+
+  function refreshStatements() {
+    fetch('/statements').then(r => r.ok ? r.json() : []).then(data => {
+      statementsBody.innerHTML = '';
+      data.forEach(st => {
+        const tr = document.createElement('tr');
+        const period = `${st.period_start} - ${st.period_end}`;
+        const created = new Date(st.generated_at).toLocaleString('ru-RU');
+        tr.innerHTML =
+          `<td>${st.id}</td>` +
+          `<td>${st.account_number}</td>` +
+          `<td>${st.owner || ''}</td>` +
+          `<td>${period}</td>` +
+          `<td>${st.status || 'сгенерирована'}</td>` +
+          `<td>${created}</td>` +
+          `<td><a class="btn btn-sm btn-outline-secondary" href="/statement/${st.id}.pdf" target="_blank">PDF</a></td>`;
+        statementsBody.appendChild(tr);
+      });
+    });
+  }
+
+  function addOperation(op = {}) {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td><input type="date" class="form-control form-control-sm op-date" value="${op.date || ''}"></td>
+      <td><input type="text" class="form-control form-control-sm op-counterparty" value="${op.counterparty || ''}"></td>
+      <td><input type="text" class="form-control form-control-sm op-description" value="${op.description || ''}"></td>
+      <td><input type="number" step="0.01" class="form-control form-control-sm op-amount" value="${op.amount != null ? op.amount : ''}"></td>
+      <td class="text-nowrap">
+        <button class="btn btn-sm btn-outline-secondary duplicate" title="Дублировать">⧉</button>
+        <button class="btn btn-sm btn-outline-danger delete" title="Удалить">✕</button>
+      </td>`;
+    opsBody.appendChild(tr);
+
+    const inputs = tr.querySelectorAll('input');
+    inputs.forEach(inp => inp.addEventListener('input', updateTotalsAndSave));
+
+    tr.querySelector('.delete').addEventListener('click', () => {
+      tr.remove();
+      updateTotalsAndSave();
+    });
+    tr.querySelector('.duplicate').addEventListener('click', () => {
+      const data = getRowData(tr);
+      addOperation(data);
+      updateTotalsAndSave();
+    });
+  }
+
+  function getRowData(tr) {
+    return {
+      date: tr.querySelector('.op-date').value,
+      counterparty: tr.querySelector('.op-counterparty').value,
+      description: tr.querySelector('.op-description').value,
+      amount: parseFloat(tr.querySelector('.op-amount').value || 0)
+    };
+  }
+
+  function gatherData() {
+    const operations = Array.from(opsBody.querySelectorAll('tr')).map(tr => getRowData(tr));
+    return {
+      account: accountInput.value.trim(),
+      fio: ownerInput.value.trim(),
+      from: startInput.value,
+      to: endInput.value,
+      opening_balance: parseFloat(openingInput.value || 0),
+      operations
+    };
+  }
+
+  function updateTotals() {
+    let incoming = 0, outgoing = 0;
+    Array.from(opsBody.querySelectorAll('tr')).forEach(tr => {
+      const val = parseFloat(tr.querySelector('.op-amount').value || 0);
+      if (val >= 0) incoming += val; else outgoing += Math.abs(val);
+    });
+    const opening = parseFloat(openingInput.value || 0);
+    const closing = opening + incoming - outgoing;
+    incomingEl.textContent = incoming.toFixed(2);
+    outgoingEl.textContent = outgoing.toFixed(2);
+    closingEl.textContent = closing.toFixed(2);
+  }
+
+  function updateTotalsAndSave() {
+    updateTotals();
+    saveDraftDebounced();
+  }
+
+  openingInput.addEventListener('input', updateTotalsAndSave);
+  accountInput.addEventListener('input', saveDraftDebounced);
+  ownerInput.addEventListener('input', saveDraftDebounced);
+  startInput.addEventListener('input', saveDraftDebounced);
+  endInput.addEventListener('input', saveDraftDebounced);
+
+  addOpBtn.addEventListener('click', () => {
+    addOperation();
+    saveDraftDebounced();
+  });
+
+  function saveDraft() {
+    const data = gatherData();
+    localStorage.setItem('statementDraft', JSON.stringify(data));
+    saveStatus.textContent = 'Сохранено';
+  }
+
+  function saveDraftDebounced() {
+    saveStatus.textContent = 'Сохранение...';
+    clearTimeout(saveTimeout);
+    saveTimeout = setTimeout(saveDraft, 1500);
+  }
+
+  saveBtn.addEventListener('click', saveDraft);
+
+  function loadDraft() {
+    const raw = localStorage.getItem('statementDraft');
+    opsBody.innerHTML = '';
+    if (raw) {
+      try {
+        const data = JSON.parse(raw);
+        accountInput.value = data.account || '';
+        ownerInput.value = data.fio || '';
+        startInput.value = data.from || '';
+        endInput.value = data.to || '';
+        openingInput.value = data.opening_balance || 0;
+        (data.operations || []).forEach(addOperation);
+      } catch (e) {
+        addOperation();
+      }
+    } else {
+      addOperation();
+    }
+    updateTotals();
+    saveStatus.textContent = '';
+  }
+
+  pdfBtn.addEventListener('click', async () => {
+    const data = gatherData();
+    const payload = {
+      fio: data.fio,
+      account: data.account,
+      from: data.from,
+      to: data.to,
+      operations: data.operations
+    };
+    const resp = await fetch('/statement/custom', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    if (!resp.ok) {
+      alert('Ошибка генерации');
+      return;
+    }
+    const blob = await resp.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'statement.pdf';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  });
+
+  refreshStatements();
+})();
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,35 +2,95 @@
 <html lang="ru">
 <head>
   <meta charset="UTF-8">
-  <title>Генератор выписок</title>
+  <title>Выписки</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='bootstrap.min.css') }}">
 </head>
 <body>
 <div class="container my-4">
-  <h1 class="mb-4">Создание выписки</h1>
-  <form id="generateForm">
+  <!-- Dashboard -->
+  <div id="dashboard">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h1 class="mb-0">Выписки</h1>
+      <button id="newStatementBtn" class="btn btn-primary">Новая выписка</button>
+    </div>
     <div class="mb-3">
-      <label for="accountSelect" class="form-label">Счёт</label>
-      <select id="accountSelect" class="form-select" required></select>
+      <input id="searchInput" class="form-control" placeholder="Поиск по счёту или ФИО">
     </div>
-    <div class="row g-3">
-      <div class="col-md-6">
-        <label for="dbStart" class="form-label">Дата начала</label>
-        <input type="date" class="form-control" id="dbStart" required>
-      </div>
-      <div class="col-md-6">
-        <label for="dbEnd" class="form-label">Дата окончания</label>
-        <input type="date" class="form-control" id="dbEnd" required>
-      </div>
-    </div>
-    <button type="submit" class="btn btn-primary mt-3">Создать выписку</button>
-    <div id="generatedLink" class="mt-3"></div>
-  </form>
+    <table class="table table-sm" id="statementsTable">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Счёт</th>
+          <th>Владелец</th>
+          <th>Период</th>
+          <th>Статус</th>
+          <th>Создано</th>
+          <th>Действия</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
 
-  <h2 class="mt-5">Ранее созданные выписки</h2>
-  <ul id="statementsList" class="list-group"></ul>
+  <!-- Editor -->
+  <div id="editor" class="d-none">
+    <button id="backToDashboard" class="btn btn-link mb-3">&larr; Назад</button>
+    <h2 class="mb-3">Создание выписки</h2>
+    <div class="row g-3 mb-3">
+      <div class="col-md-4">
+        <label class="form-label">Счёт</label>
+        <input type="text" id="accountInput" class="form-control" required>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">ФИО владельца</label>
+        <input type="text" id="ownerInput" class="form-control" required>
+      </div>
+      <div class="col-md-2">
+        <label class="form-label">Дата начала</label>
+        <input type="date" id="periodStart" class="form-control" required>
+      </div>
+      <div class="col-md-2">
+        <label class="form-label">Дата конца</label>
+        <input type="date" id="periodEnd" class="form-control" required>
+      </div>
+    </div>
+
+    <div class="row g-3 mb-3">
+      <div class="col-md-4">
+        <label class="form-label">Входящий остаток</label>
+        <input type="number" step="0.01" id="openingBalance" class="form-control" value="0">
+      </div>
+      <div class="col-md-8 d-flex align-items-end">
+        <div>
+          <span class="me-3">Поступление: <span id="totalIncoming">0</span></span>
+          <span class="me-3">Списание: <span id="totalOutgoing">0</span></span>
+          <span>Закрывающий остаток: <span id="closingBalance">0</span></span>
+        </div>
+      </div>
+    </div>
+
+    <table class="table table-sm" id="operationsTable">
+      <thead>
+        <tr>
+          <th style="width:10%">Дата</th>
+          <th style="width:25%">Плательщик / Получатель</th>
+          <th style="width:45%">Операция</th>
+          <th style="width:15%">Сумма (RUB)</th>
+          <th style="width:5%"></th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <button id="addOperation" type="button" class="btn btn-secondary btn-sm">Добавить новую операцию</button>
+
+    <div class="mt-4">
+      <button id="saveDraft" type="button" class="btn btn-outline-secondary">Сохранить</button>
+      <button id="generatePdf" type="button" class="btn btn-primary">Сгенерировать и скачать PDF</button>
+    </div>
+    <div id="saveStatus" class="mt-2 text-muted"></div>
+  </div>
 </div>
-<script src="{{ url_for('static', filename='app.js') }}"></script>
+<script src="{{ url_for('static', filename='ui.js') }}"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- introduce dashboard to view and create statements
- implement interactive statement editor with operations table and totals
- add client-side draft saving and PDF generation via existing API

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688c66b6b8d8832ebdde88069fd9b017