### PR TITLE
Fix PDF generation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 Flask>=3.0.0
 SQLAlchemy>=2.0.30
 Jinja2>=3.1.3
-WeasyPrint>=60.2
+pydyf>=0.11.0
+WeasyPrint>=66.0
 PyPDF2>=3.0.1
 psycopg2-binary>=2.9.9
 gunicorn>=20


### PR DESCRIPTION
## Summary
- ensure pydyf accepts optional arguments expected by some WeasyPrint versions
- pin WeasyPrint and pydyf versions in requirements

## Testing
- `python - <<'PY'
from statement_generator import render_pdf
pdf_bytes = render_pdf('<html><body>Test</body></html>')
print('generated', len(pdf_bytes), 'bytes')
PY`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c6b37c800832e8da29aac8d59df1f