### PR TITLE
Refine statement PDF layout

### DIFF
--- a/static/logo.svg
+++ b/static/logo.svg
@@ -1,4 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="60" height="20">
-  <rect width="60" height="20" fill="#E40000"/>
-  <text x="30" y="14" font-size="12" font-family="DejaVu Sans" fill="#ffffff" text-anchor="middle">LOGO</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="40" viewBox="0 0 160 40">
+  <circle cx="20" cy="10" r="10" fill="#e30613"/>
+  <rect x="10" y="30" width="20" height="5" fill="#e30613"/>
+  <text x="45" y="18" font-family="DejaVu Sans" font-weight="bold" font-size="12" fill="#000">БАНК</text>
+  <text x="45" y="32" font-family="DejaVu Sans" font-weight="bold" font-size="12" fill="#000">САНКТ-ПЕТЕРБУРГ</text>
 </svg>

--- a/templates/statement.html
+++ b/templates/statement.html
@@ -3,42 +3,68 @@
 <head>
   <meta charset="utf-8"/>
   <style>
-    @page { size: A4; margin: 20mm; }
-    body { font-family: "DejaVu Sans", "Helvetica", sans-serif; font-size: 10pt; }
-    header { position: relative; margin-bottom: 10mm; }
-    header h1 { font-size: 16pt; margin: 0; }
-    header img { position: absolute; top: 0; right: 0; height: 30px; }
-    .info { margin-top: 5mm; }
-    .info div { margin-bottom: 2mm; }
-    table { width: 100%; border-collapse: collapse; margin-top: 5mm; }
-    th, td { border: 1px solid #000; padding: 2px 4px; vertical-align: top; }
-    th { background: #eee; font-weight: bold; }
-    .totals { margin-top: 5mm; }
-    footer { position: fixed; bottom: 10mm; left: 0; right: 0; font-size: 9pt; }
+    @page { size: A4; margin: 20pt; }
+    body {
+      font-family: "DejaVu Sans", "Helvetica", sans-serif;
+      font-size: 8pt;
+      color: #000;
+    }
+    h1 { font-size: 16pt; margin: 0; }
+    .header { position: relative; margin-bottom: 8pt; }
+    .header img { position: absolute; top: 0; right: 0; height: 40px; }
+    .meta { font-size: 10pt; margin-top: 8pt; }
+    .account-line {
+      display: flex;
+      justify-content: space-between;
+      font-size: 8pt;
+      margin-top: 4pt;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 8pt;
+      font-size: 8pt;
+    }
+    th, td { border: 1pt solid #000; padding: 2pt 4pt; vertical-align: top; }
+    th { font-weight: bold; text-align: left; }
+    th.amount, td.amount { text-align: right; }
+    .summary {
+      margin-top: 8pt;
+      font-size: 10pt;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+    }
+    footer {
+      position: fixed;
+      bottom: 20pt;
+      left: 20pt;
+      right: 20pt;
+      font-size: 8pt;
+    }
     footer .left { float: left; }
-    footer .center { text-align: center; }
-    footer .right { float: right; }
+    footer .center { position: absolute; left: 50%; transform: translateX(-50%); }
+    footer .right { float: right; text-align: right; }
   </style>
 </head>
 <body>
-<header>
+<div class="header">
+  <img src="static/logo.svg" alt="Банк Санкт-Петербург"/>
   <h1>Выписка</h1>
-  <img src="static/logo.svg" alt="Логотип"/>
-  <div class="info">
-    <div>Период: {{ data.statement.period_start|date }} - {{ data.statement.period_end|date }}</div>
+  <div class="meta">Период: {{ data.statement.period_start|date }} - {{ data.statement.period_end|date }}</div>
+  <div class="account-line">
     <div>Счёт: {{ data.account.number }}</div>
+    <div>Входящий остаток на {{ data.statement.period_start|date }}: {{ opening_balance|amount }}</div>
   </div>
-</header>
-
-<div>Входящий остаток на {{ data.statement.period_start|date }}: {{ opening_balance|amount }}</div>
+</div>
 
 <table>
   <thead>
     <tr>
-      <th style="width: 10%">Дата</th>
-      <th style="width: 30%">Плательщик / Получатель</th>
-      <th style="width: 40%">Операция</th>
-      <th style="width: 20%">Сумма (RUB)</th>
+      <th style="width:75pt">Дата</th>
+      <th style="width:170pt">Плательщик / Получатель</th>
+      <th>Операция</th>
+      <th class="amount" style="width:80pt">Сумма (RUB)</th>
     </tr>
   </thead>
   <tbody>
@@ -47,13 +73,12 @@
       <td>{{ t.date|date }}</td>
       <td>{{ t.counterparty or '' }}</td>
       <td>{{ t.description }}</td>
-      <td style="text-align:right">{{ t.amount|amount }}</td>
+      <td class="amount">{{ t.amount|amount }}</td>
     </tr>
     {% endfor %}
   </tbody>
 </table>
-
-<div class="totals">
+<div class="summary">
   <div>Исходящий остаток на {{ data.statement.period_end|date }}: {{ closing_balance|amount }}</div>
   <div>Поступление: {{ total_incoming|amount }}</div>
   <div>Списание: {{ total_outgoing|amount }}</div>
@@ -63,10 +88,12 @@
   <div class="left">
     <div>ПАО "БАНК "САНКТ-ПЕТЕРБУРГ"</div>
     <div>БИК 044030790</div>
-    <div>{{ data.account.user.username }}</div>
   </div>
   <div class="center">1/1</div>
-  <div class="right">{{ data.statement.created_at|datetime_msk }}</div>
+  <div class="right">
+    <div>{{ data.account.user.username }}</div>
+    <div>{{ data.statement.created_at|datetime_msk }}</div>
+  </div>
 </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- match statement template spacing and typography to bank example
- add Bank Saint Petersburg style logo
- right-align totals and amounts and adjust column widths

## Testing
- `python - <<'PY' ...` (generate sample PDF)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688c747af0a0832e9ac1d5433e6b8b0e