### PR TITLE
Refine statement template layout from pdf reference

### DIFF
--- a/templates/statement.html
+++ b/templates/statement.html
@@ -15,19 +15,19 @@
 }
 @page {
   size: A4 portrait;
-  margin: 20pt 18pt 50pt 22pt;
+  margin: 8pt 0 30pt 24pt;
   @bottom-center {
     content: counter(page) " / " counter(pages);
-    font-size: 9pt;
+    font-size: 8pt;
   }
 }
 body, table {
   font-family: "DejaVuSans", sans-serif;
-  font-size: 10pt;
+  font-size: 8pt;
   line-height: 1.2;
 }
 h1 {
-  font-size: 14pt;
+  font-size: 16pt;
   font-weight: bold;
   margin: 0;
 }
@@ -44,15 +44,15 @@ h1 {
   font-weight: bold;
 }
 .operations {
-  width: 555pt;
+  width: 571pt;
   border-collapse: collapse;
   table-layout: fixed;
   margin-top: 10pt;
 }
 .operations col:nth-child(1){width:68pt;}
-.operations col:nth-child(2){width:175pt;}
-.operations col:nth-child(3){width:212pt;}
-.operations col:nth-child(4){width:100pt;}
+.operations col:nth-child(2){width:173pt;}
+.operations col:nth-child(3){width:246pt;}
+.operations col:nth-child(4){width:84pt;}
 .operations th, .operations td {
   border: 0.5pt solid #000;
   padding: 2pt;
@@ -71,10 +71,10 @@ h1 {
 }
 footer {
   position: fixed;
-  bottom: 20pt;
-  left: 22pt;
-  right: 18pt;
-  font-size: 9pt;
+  bottom: 8pt;
+  left: 24pt;
+  right: 0;
+  font-size: 8pt;
   display: flex;
   justify-content: space-between;
   align-items: flex-start;


### PR DESCRIPTION
## Summary
- adjust page margins and fonts to more closely match bank statement layout
- use column widths from reference PDF for operations table
- reposition footer to match PDF coordinates

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688d2bec2264832e92050bf1e9787339