### PR TITLE
Rebuild statement template from PDF HTML

### DIFF
--- a/templates/statement.html
+++ b/templates/statement.html
@@ -15,156 +15,100 @@
 }
 @page {
   size: A4 portrait;
-  margin: 8pt 0 30pt 24pt;
-  @bottom-center {
-    content: counter(page) " / " counter(pages);
-    font-size: 8pt;
-  }
-}
-body, table {
-  font-family: "DejaVuSans", sans-serif;
-  font-size: 8pt;
-  line-height: 1.2;
-}
-h1 {
-  font-size: 16pt;
-  font-weight: bold;
   margin: 0;
 }
-.header-table {
-  width: 100%;
-  margin-top: 4pt;
-  border-collapse: collapse;
+body{
+  background-color: slategray;
+  margin:0;
 }
-.header-table td {
-  padding: 0;
+div.page{
+  position:relative;
+  background-color:white;
+  margin:1em auto;
+  box-shadow:1px 1px 8px -2px black;
+  width:595pt;
+  height:842pt;
+  font-family:"DejaVuSans",sans-serif;
+  font-size:8pt;
+  line-height:1.2;
 }
-.header-table td:last-child {
-  text-align: right;
-  font-weight: bold;
+p{position:absolute;white-space:pre;margin:0;}
+h1{position:absolute;top:22pt;left:20pt;font-size:16pt;font-weight:bold;margin:0;}
+img.logo{position:absolute;top:20pt;right:20pt;height:32pt;}
+table.operations{
+  position:absolute;
+  top:104.5pt;
+  left:20pt;
+  width:571pt;
+  border-collapse:collapse;
+  table-layout:fixed;
 }
-.operations {
-  width: 571pt;
-  border-collapse: collapse;
-  table-layout: fixed;
-  margin-top: 10pt;
-}
-.operations col:nth-child(1){width:68pt;}
-.operations col:nth-child(2){width:173pt;}
-.operations col:nth-child(3){width:246pt;}
-.operations col:nth-child(4){width:84pt;}
-.operations th, .operations td {
-  border: 0.5pt solid #000;
-  padding: 2pt;
-  vertical-align: top;
-}
-.operations td {
-  word-break: break-word;
-  overflow-wrap: anywhere;
-}
-.operations thead th {
-  font-weight: bold;
-}
-.operations td:last-child {
-  text-align: right;
-  vertical-align: bottom;
-}
-footer {
-  position: fixed;
-  bottom: 8pt;
-  left: 24pt;
-  right: 0;
-  font-size: 8pt;
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-}
-footer .left {
-  display: flex;
-  gap: 5pt;
-}
-footer .left .text {
-  display: flex;
-  flex-direction: column;
-}
-footer .right {
-  text-align: right;
-}
+table.operations col:nth-child(1){width:68pt;}
+table.operations col:nth-child(2){width:173pt;}
+table.operations col:nth-child(3){width:246pt;}
+table.operations col:nth-child(4){width:84pt;}
+table.operations th,table.operations td{border:0.5pt solid #000;padding:2pt;vertical-align:top;}
+table.operations td{word-break:break-word;overflow-wrap:anywhere;}
+table.operations th{font-weight:bold;}
+table.operations td:last-child{text-align:right;vertical-align:bottom;}
+.footer-left{position:absolute;top:781.1pt;left:20pt;font-size:9pt;}
+.footer-left2{position:absolute;top:791.6pt;left:20pt;font-size:9pt;}
+.footer-right-name{position:absolute;top:781.3pt;left:389.7pt;font-size:10pt;}
+.footer-right-time{position:absolute;top:792.9pt;left:474.3pt;font-size:10pt;}
 </style>
 </head>
 
 <body>
-  <div class="page">
-    <img src="out001.png" alt="background image" class="background"/>
-    <img src="static/logo.png" alt="Логотип" class="logo"/>
+<div class="page">
+  <img src="static/logo.png" alt="Логотип" class="logo"/>
 
-    <div class="content">
-      <h1>Выписка</h1>
-      <p>
-        Период: {{ data.statement.period_start|date }}
-        –
-        {{ data.statement.period_end|date }}
-      </p>
+  <h1>Выписка</h1>
+  <p style="top:61.3pt;left:20pt;line-height:10pt;">Период: {{ data.statement.period_start|date }} - {{ data.statement.period_end|date }}</p>
+  <p style="top:88.4pt;left:22pt;line-height:8pt;font-weight:bold;">Счёт: {{ data.account.number|account_format }}</p>
+  <p style="top:88.4pt;left:318pt;line-height:8pt;font-weight:bold;">Входящий остаток на {{ data.statement.period_start|date }}</p>
+  <p style="top:88.4pt;left:552.3pt;line-height:8pt;font-weight:bold;">{{ opening_balance|rub_format }}</p>
 
-      <table class="header-table">
-        <tr>
-          <td colspan="2">Счёт: {{ data.account.number|account_format }}</td>
-        </tr>
-        <tr>
-          <td>Входящий остаток на {{ data.statement.period_start|date }}</td>
-          <td>{{ opening_balance|rub_format }}</td>
-        </tr>
-      </table>
+  <table class="operations">
+    <colgroup><col/><col/><col/><col/></colgroup>
+    <thead>
+      <tr>
+        <th>Дата</th>
+        <th>Плательщик / Получатель</th>
+        <th>Операция</th>
+        <th>Сумма (RUB)</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for t in data.transactions %}
+      <tr>
+        <td>{{ t.date|date }}</td>
+        <td>{{ t.counterparty or '' }}</td>
+        <td>{{ t.description }}</td>
+        <td>{{ t.amount|rub_format }}</td>
+      </tr>
+      {% endfor %}
+      <tr>
+        <td colspan="3">Исходящий остаток на {{ data.statement.period_end|date }}</td>
+        <td style="font-weight:bold;">{{ closing_balance|rub_format }}</td>
+      </tr>
+      <tr>
+        <td colspan="2"></td>
+        <td>Поступление</td>
+        <td>{{ total_incoming|rub_format }}</td>
+      </tr>
+      <tr>
+        <td colspan="2"></td>
+        <td>Списание</td>
+        <td>{{ total_outgoing|rub_format }}</td>
+      </tr>
+    </tbody>
+  </table>
 
-      <table class="operations">
-        <colgroup><col/><col/><col/><col/></colgroup>
-        <thead>
-          <tr>
-            <th>Дата</th>
-            <th>Плательщик / Получатель</th>
-            <th>Операция</th>
-            <th>Сумма (RUB)</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for t in data.transactions %}
-          <tr>
-            <td>{{ t.date|date }}</td>
-            <td>{{ t.counterparty or '' }}</td>
-            <td>{{ t.description }}</td>
-            <td>{{ t.amount|rub_format }}</td>
-          </tr>
-          {% endfor %}
-          <tr>
-            <td colspan="3">Исходящий остаток на {{ data.statement.period_end|date }}</td>
-            <td style="font-weight:bold;">{{ closing_balance|rub_format }}</td>
-          </tr>
-          <tr>
-            <td colspan="2"></td>
-            <td>Поступление</td>
-            <td>{{ total_incoming|rub_format }}</td>
-          </tr>
-          <tr>
-            <td colspan="2"></td>
-            <td>Списание</td>
-            <td>{{ total_outgoing|rub_format }}</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-
-    <footer>
-      <div class="left">
-        <div class="text">
-          <div>ПАО «БАНК САНКТ-ПЕТЕРБУРГ»</div>
-          <div>БИК 044030790</div>
-        </div>
-      </div>
-      <div class="right">
-        <div>{{ data.account.user.username }}</div>
-        <div>{{ data.statement.created_at|format_ts }}</div>
-      </div>
-    </footer>
-  </div>
+  <p class="footer-left">ПАО «БАНК САНКТ-ПЕТЕРБУРГ»</p>
+  <p class="footer-left2">БИК 044030790</p>
+  <p class="footer-right-name">{{ data.account.user.username }}</p>
+  <p class="footer-right-time">{{ data.statement.created_at|format_ts }}</p>
+</div>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- Replace statement template with HTML converted from the PDF layout, using absolute positioning and A4 canvas
- Render operations in a fixed-width table that wraps long text without altering column widths
- Display bank logo in the top-right corner of the statement

## Testing
- `python -m py_compile $(git ls-files '*.py') && echo 'py_compile success'`
- `python - <<'PY'
from sample_data import SessionLocal
from models import Account, Statement, Transaction
from statement_generator import generate_statement_pdf, StatementData
from datetime import date, datetime
session = SessionLocal()
account = session.query(Account).first()
txs = session.query(Transaction).all()
statement = Statement(account_id=account.id, period_start=date(2024,1,1), period_end=date(2024,3,1), created_at=datetime.now())
data = StatementData(statement=statement, account=account, transactions=txs)
pdf_bytes = generate_statement_pdf(data)
print('PDF bytes:', len(pdf_bytes))
PY`

------
https://chatgpt.com/codex/tasks/task_e_688dd0ea3254832e99aadcf11afe1b4d