### PR TITLE
Adjust statement table to use horizontal lines only

### DIFF
--- a/templates/statement.html
+++ b/templates/statement.html
@@ -42,22 +42,23 @@ table.operations{
   width:571pt;
   border-collapse:collapse;
   table-layout:fixed;
-  border:1pt solid #000;
 }
 table.operations col:nth-child(1){width:68pt;}
 table.operations col:nth-child(2){width:173pt;}
 table.operations col:nth-child(3){width:246pt;}
 table.operations col:nth-child(4){width:84pt;}
-table.operations th,table.operations td{border:0.5pt solid #000;padding:2pt;vertical-align:top;}
-table.operations th{font-weight:bold;border-bottom:1pt solid #000;}
+table.operations th,table.operations td{padding:2pt;vertical-align:top;}
+table.operations th{font-weight:bold;border-bottom:0.5pt solid #000;}
 table.operations td{word-break:break-word;overflow-wrap:anywhere;}
+table.operations tr:not(.closing-row):not(.totals-row) td{border-bottom:0.5pt solid #000;}
 table.operations td:last-child{text-align:right;vertical-align:bottom;}
-table.operations tr:last-child td{border-bottom:1pt solid #000;}
-table.operations tr.closing-row td{border-top:1pt solid #000;font-weight:bold;}
+table.operations tr.closing-row td{border-top:0.5pt solid #000;border-bottom:0.5pt solid #000;font-weight:bold;}
+table.operations tr.totals-row td{font-weight:bold;border-bottom:0;}
+table.operations tr.totals-row:last-child td{border-bottom:0.5pt solid #000;}
+table.operations tr.last-op-row td{border-bottom:0;}
 table.operations td.closing-label{padding-left:57pt;}
 table.operations td.total-in{padding-left:151pt;font-weight:bold;}
 table.operations td.total-out{padding-left:167pt;font-weight:bold;}
-table.operations tr.totals-row td{font-weight:bold;}
 .footer-left{position:absolute;top:781.1pt;left:20pt;font-size:9pt;}
 .footer-left2{position:absolute;top:791.6pt;left:20pt;font-size:9pt;}
 .footer-right-name{position:absolute;top:781.3pt;left:389.7pt;font-size:10pt;}
@@ -87,7 +88,7 @@ table.operations tr.totals-row td{font-weight:bold;}
     </thead>
     <tbody>
       {% for t in data.transactions %}
-      <tr>
+      <tr{% if loop.last %} class="last-op-row"{% endif %}>
         <td>{{ t.date|date }}</td>
         <td>{{ t.counterparty or '' }}</td>
         <td>{{ t.description }}</td>


### PR DESCRIPTION
## Summary
- Drop outer borders and vertical lines from statement table
- Add horizontal separators and special handling for closing and totals rows
- Mark last operation row to avoid double lines before summary

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688dd754e0ac832eba52bd6ed0f34145