### PR TITLE
Fix margins and heading weight in statement template

### DIFF
--- a/templates/statement.html
+++ b/templates/statement.html
@@ -33,13 +33,13 @@ div.page{
   line-height:1.2;
 }
 p{position:absolute;white-space:pre;margin:0;}
-h1{position:absolute;top:22pt;left:20pt;font-size:16pt;font-weight:bold;margin:0;}
+h1{position:absolute;top:22pt;left:20pt;font-size:16pt;font-weight:normal;margin:0;}
 img.logo{position:absolute;top:20pt;right:20pt;height:32pt;}
 div.account-summary{
   position:absolute;
   top:80pt;
   left:20pt;
-  width:571pt;
+  width:555pt;
   height:24.5pt;
   border-top:0.5pt solid #000;
   border-bottom:0.5pt solid #000;
@@ -52,19 +52,19 @@ div.account-summary p{
 }
 div.account-summary p.account{left:2pt;}
 div.account-summary p.opening-label{left:298pt;}
-div.account-summary p.opening-amount{left:532.3pt;}
+div.account-summary p.opening-amount{left:516.3pt;}
 table.operations{
   position:absolute;
   top:104.5pt;
   left:20pt;
-  width:571pt;
+  width:555pt;
   border-collapse:collapse;
   table-layout:fixed;
 }
 table.operations col:nth-child(1){width:68pt;}
 table.operations col:nth-child(2){width:173pt;}
 table.operations col:nth-child(3){width:246pt;}
-table.operations col:nth-child(4){width:84pt;}
+table.operations col:nth-child(4){width:68pt;}
 /* Заголовок: жирная нижняя граница */
 table.operations thead th {
   padding: 4px 6px;
@@ -115,8 +115,8 @@ table.operations td.total-in{padding-left:151pt;font-weight:bold;}
 table.operations td.total-out{padding-left:167pt;font-weight:bold;}
 .footer-left{position:absolute;top:781.1pt;left:20pt;font-size:9pt;}
 .footer-left2{position:absolute;top:791.6pt;left:20pt;font-size:9pt;}
-.footer-right-name{position:absolute;top:781.3pt;left:389.7pt;font-size:10pt;}
-.footer-right-time{position:absolute;top:792.9pt;left:474.3pt;font-size:10pt;}
+.footer-right-name{position:absolute;top:781.3pt;left:373.7pt;font-size:10pt;}
+.footer-right-time{position:absolute;top:792.9pt;left:458.3pt;font-size:10pt;}
 </style>
 </head>
 


### PR DESCRIPTION
## Summary
- Equalize right margin with left by narrowing content width and adjusting positions
- Lighten the "Выписка" heading weight to normal while keeping size

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688de92bb1c4832e83472ee9a80b56d6