### PR TITLE
Remove gray field above generated PDF

### DIFF
--- a/templates/statement.html
+++ b/templates/statement.html
@@ -17,20 +17,20 @@
   size: A4 portrait;
   margin: 0;
 }
-body{
-  background-color: slategray;
-  margin:0;
+body {
+  margin: 0;
+  background: #fff;
 }
-div.page{
-  position:relative;
-  background-color:white;
-  margin:1em auto;
-  box-shadow:1px 1px 8px -2px black;
-  width:595pt;
-  height:842pt;
-  font-family:"DejaVuSans",sans-serif;
-  font-size:8pt;
-  line-height:1.2;
+div.page {
+  position: relative;
+  background-color: white;
+  margin: 0 auto;
+  box-shadow: 1px 1px 8px -2px black;
+  width: 595pt;
+  height: 842pt;
+  font-family: "DejaVuSans", sans-serif;
+  font-size: 8pt;
+  line-height: 1.2;
 }
 p{position:absolute;white-space:pre;margin:0;}
 h1{position:absolute;top:22pt;left:20pt;font-size:16pt;font-weight:normal;margin:0;}


### PR DESCRIPTION
## Summary
- ensure generated statement PDFs have no gray bar by dropping body background and top margin

## Testing
- `pytest -q`
- Generated sample statement PDF to confirm rendering

------
https://chatgpt.com/codex/tasks/task_e_688deb86791c832ea7da514975a55b71