### PR TITLE
Trim account summary spacing in statement template

### DIFF
--- a/templates/statement.html
+++ b/templates/statement.html
@@ -40,13 +40,13 @@ div.account-summary{
   top:80pt;
   left:20pt;
   width:555pt;
-  height:24.5pt;
+  height:16pt;
   border-top:0.5pt solid #000;
   border-bottom:0.5pt solid #000;
 }
 div.account-summary p{
   position:absolute;
-  top:8.4pt;
+  top:4pt;
   line-height:8pt;
   font-weight:bold;
 }
@@ -64,7 +64,7 @@ div.account-summary p.opening-amount{left:516.3pt;}
 }
 table.operations{
   position:absolute;
-  top:104.5pt;
+  top:96pt;
   left:20pt;
   width:555pt;
   border-collapse:collapse;


### PR DESCRIPTION
## Summary
- Reduce excess vertical spacing around account number and opening balance
- Move operations table up to match new account summary height

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688dece453f4832e86907f4da2f466ac