### PR TITLE
Handle opening balance in custom statement PDFs

### DIFF
--- a/statement_generator.py
+++ b/statement_generator.py
@@ -74,6 +74,7 @@ class StatementData:
     statement: Statement
     account: Account
     transactions: Iterable[Transaction]
+    opening_balance: Optional[float] = None
 
 
 def generate_statement_pdf(data: StatementData, template_pdf: Optional[Path] = None) -> bytes:
@@ -86,7 +87,10 @@ def generate_statement_pdf(data: StatementData, template_pdf: Optional[Path] = N
     env.filters["format_ts"] = format_ts
 
     txs = list(data.transactions)
-    opening_balance = txs[0].balance - txs[0].amount if txs else 0
+    if data.opening_balance is not None:
+        opening_balance = data.opening_balance
+    else:
+        opening_balance = txs[0].balance - txs[0].amount if txs else 0
     closing_balance = txs[-1].balance if txs else opening_balance
     total_incoming = sum(t.amount for t in txs if t.amount > 0)
     total_outgoing = sum(t.amount for t in txs if t.amount < 0)

--- a/static/ui.js
+++ b/static/ui.js
@@ -185,6 +185,7 @@
       account: data.account,
       from: data.from,
       to: data.to,
+      opening_balance: data.opening_balance,
       operations: data.operations
     };
     const resp = await fetch('/statement/custom', {


### PR DESCRIPTION
## Summary
- Pass user-specified opening balance from UI to backend
- Use opening balance when generating custom statements and PDFs
- Allow `statement_generator` to accept predefined opening balance

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688df0906ee0832eb0c0d1723fcb9066