### PR TITLE
fix: handle opening balance and totals

### DIFF
--- a/app.py
+++ b/app.py
@@ -139,7 +139,8 @@ def statement_custom():
         account_number = payload["account"]
         start = datetime.fromisoformat(payload["from"]).date()
         end = datetime.fromisoformat(payload["to"]).date()
-        opening_balance = float(payload.get("opening_balance", 0))
+        opening_raw = payload.get("opening_balance")
+        opening_balance = float(opening_raw) if opening_raw is not None else None
         ops = payload.get("operations", [])
     except KeyError as e:
         return jsonify({"error": f"Отсутствует поле: {e.args[0]}"}), 400
@@ -150,7 +151,7 @@ def statement_custom():
     account = SimpleAccount(number=account_number, user=user)
     statement = SimpleStatement(period_start=start, period_end=end)
 
-    running_balance = opening_balance
+    running_balance = opening_balance or 0
     transactions: list[SimpleTransaction] = []
     for op in ops:
         try:

--- a/statement_generator.py
+++ b/statement_generator.py
@@ -93,7 +93,7 @@ def generate_statement_pdf(data: StatementData, template_pdf: Optional[Path] = N
         opening_balance = txs[0].balance - txs[0].amount if txs else 0
     closing_balance = txs[-1].balance if txs else opening_balance
     total_incoming = sum(t.amount for t in txs if t.amount > 0)
-    total_outgoing = sum(t.amount for t in txs if t.amount < 0)
+    total_outgoing = -sum(t.amount for t in txs if t.amount < 0)
 
     template = env.get_template("statement.html")
     html = template.render(


### PR DESCRIPTION
## Summary
- Preserve provided opening balance in custom statements
- Show outgoing totals as positive amounts in statement PDF

## Testing
- `python -m py_compile app.py statement_generator.py`
- Generated sample PDF via test client to ensure opening balance and totals render correctly

------
https://chatgpt.com/codex/tasks/task_e_688df414fa38832e8f23ee1fe88d94ef