### PR TITLE
Fix opening balance usage and sign of outgoing totals

### DIFF
--- a/app.py
+++ b/app.py
@@ -206,6 +206,7 @@ def generate_statement():
         return jsonify({"error": f"Ошибка разбора даты/ид: {e}"}), 400
 
     user = payload.get("user", "system")
+    opening_raw = payload.get("opening_balance")
 
     with SessionLocal() as db:
         account = db.get(Account, account_id)
@@ -218,14 +219,20 @@ def generate_statement():
             .order_by(Transaction.date, Transaction.id)
             .all()
         )
-        opening_tx = (
-            db.query(Transaction)
-            .filter(Transaction.account_id == account_id)
-            .filter(Transaction.date < start)
-            .order_by(Transaction.date.desc(), Transaction.id.desc())
-            .first()
-        )
-        opening_balance = float(opening_tx.balance) if opening_tx else 0.0
+        if opening_raw is not None:
+            try:
+                opening_balance = float(opening_raw)
+            except (TypeError, ValueError):
+                return jsonify({"error": "Ошибка разбора opening_balance"}), 400
+        else:
+            opening_tx = (
+                db.query(Transaction)
+                .filter(Transaction.account_id == account_id)
+                .filter(Transaction.date < start)
+                .order_by(Transaction.date.desc(), Transaction.id.desc())
+                .first()
+            )
+            opening_balance = float(opening_tx.balance) if opening_tx else 0.0
         statement = Statement(
             account_id=account.id,
             period_start=start,

--- a/statement_generator.py
+++ b/statement_generator.py
@@ -109,7 +109,8 @@ def generate_statement_pdf(data: StatementData, template_pdf: Optional[Path] = N
         opening_balance = txs[0].balance - txs[0].amount if txs else 0
     closing_balance = txs[-1].balance if txs else opening_balance
     total_incoming = sum(t.amount for t in txs if t.amount > 0)
-    total_outgoing = -sum(t.amount for t in txs if t.amount < 0)
+    # keep outgoing totals negative so the PDF displays the minus sign
+    total_outgoing = sum(t.amount for t in txs if t.amount < 0)
 
     template = env.get_template("statement.html")
     html = template.render(


### PR DESCRIPTION
## Summary
- allow overriding opening balance via `opening_balance` field when generating statements
- keep outgoing totals negative so PDF shows minus sign

## Testing
- `python -m py_compile app.py statement_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_688e0240a014832e811d43e39ca5bcad