### PR TITLE
Fix outgoing totals sign and clarify opening balance

### DIFF
--- a/app.py
+++ b/app.py
@@ -77,6 +77,14 @@ def parse_iso_date(value: Optional[str]) -> Optional[date]:
             return None
 
 
+def parse_amount(value):
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = value.replace(" ", "").replace(",", ".")
+    return float(value)
+
+
 @app.route("/")
 def index():
     return render_template("index.html")
@@ -140,7 +148,7 @@ def statement_custom():
         start = datetime.fromisoformat(payload["from"]).date()
         end = datetime.fromisoformat(payload["to"]).date()
         opening_raw = payload.get("opening_balance")
-        opening_balance = float(opening_raw) if opening_raw is not None else None
+        opening_balance = parse_amount(opening_raw) if opening_raw is not None else None
         ops = payload.get("operations", [])
     except KeyError as e:
         return jsonify({"error": f"Отсутствует поле: {e.args[0]}"}), 400
@@ -156,7 +164,7 @@ def statement_custom():
     for op in ops:
         try:
             dt = datetime.fromisoformat(op["date"]).date()
-            amount = float(op["amount"])
+            amount = parse_amount(op["amount"])
             desc = op.get("description", "")
             cp = op.get("counterparty", "")
         except KeyError as e:

--- a/statement_generator.py
+++ b/statement_generator.py
@@ -109,7 +109,7 @@ def generate_statement_pdf(data: StatementData, template_pdf: Optional[Path] = N
         opening_balance = txs[0].balance - txs[0].amount if txs else 0
     closing_balance = txs[-1].balance if txs else opening_balance
     total_incoming = sum(t.amount for t in txs if t.amount > 0)
-    total_outgoing = -sum(t.amount for t in txs if t.amount < 0)
+    total_outgoing = sum(t.amount for t in txs if t.amount < 0)
 
     template = env.get_template("statement.html")
     html = template.render(

--- a/static/ui.js
+++ b/static/ui.js
@@ -93,7 +93,8 @@
   }
 
   function getNumber(input) {
-    const val = input.valueAsNumber;
+    const raw = input.value.replace(/\s+/g, '').replace(',', '.');
+    const val = parseFloat(raw);
     return Number.isNaN(val) ? 0 : val;
   }
 
@@ -122,10 +123,10 @@
     let incoming = 0, outgoing = 0;
     Array.from(opsBody.querySelectorAll('tr')).forEach(tr => {
       const val = getNumber(tr.querySelector('.op-amount'));
-      if (val >= 0) incoming += val; else outgoing += Math.abs(val);
+      if (val >= 0) incoming += val; else outgoing += val;
     });
     const opening = getNumber(openingInput);
-    const closing = opening + incoming - outgoing;
+    const closing = opening + incoming + outgoing;
     incomingEl.textContent = incoming.toFixed(2);
     outgoingEl.textContent = outgoing.toFixed(2);
     closingEl.textContent = closing.toFixed(2);


### PR DESCRIPTION
## Summary
- Preserve negative sign for outgoing totals when generating statement PDFs
- Adjust frontend totals so outgoing and closing balances reflect negative amounts
- Parse numbers with commas or spaces so the provided opening balance appears in PDFs

## Testing
- `pytest`
- `python - <<'PY' ... (sample PDF generation with opening balance)`

------
https://chatgpt.com/codex/tasks/task_e_688e0240a014832e811d43e39ca5bcad