### PR TITLE
Ensure opening balance is passed verbatim to backend

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -114,7 +114,8 @@
       fio: ownerInput.value.trim(),
       from: startInput.value,
       to: endInput.value,
-      opening_balance: getNumber(openingInput),
+      // Передаём исходную строку, чтобы сервер сам разобрал формат числа
+      opening_balance: openingInput.value.trim(),
       operations
     };
   }


### PR DESCRIPTION
## Summary
- send opening balance as raw string instead of parsed float

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688e0d491b10832ebc5074ad7330b667