### PR TITLE
Align opening balance amount

### DIFF
--- a/templates/statement.html
+++ b/templates/statement.html
@@ -52,7 +52,7 @@ div.account-summary p{
 }
 div.account-summary p.account{left:2pt;}
 div.account-summary p.opening-label{left:298pt;}
-div.account-summary p.opening-amount{left:516.3pt;}
+div.account-summary p.opening-amount{right:2pt;text-align:right;}
 .period {
   position: absolute;
   top: 61.3pt;


### PR DESCRIPTION
## Summary
- right-align the opening balance amount in the account summary to keep values positioned even when they grow

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e132e954c832ebdc26447b9b6b561