### PR TITLE
Allow server IP address

### DIFF
--- a/bspb_site/settings.py
+++ b/bspb_site/settings.py
@@ -9,7 +9,10 @@ STATEMENTS_DIR.mkdir(parents=True, exist_ok=True)
 
 SECRET_KEY = os.environ.get('SECRET_KEY', 'dev-secret-key')
 DEBUG = True
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ['localhost', '127.0.0.1', '109.120.185.161']
+
+# Allow CSRF requests from the server's public address
+CSRF_TRUSTED_ORIGINS = ['http://109.120.185.161:3000']
 
 INSTALLED_APPS = [
     'django.contrib.admin',


### PR DESCRIPTION
## Summary
- allow requests from 109.120.185.161 in Django settings
- trust CSRF requests originating from the same public address

## Testing
- `pip install -r requirements.txt`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_688e1b66fe8c832ea7e60b813c3fcb9d