### PR TITLE
Fix template modal input after saving

### DIFF
--- a/static/ui.js
+++ b/static/ui.js
@@ -102,7 +102,7 @@
     saveTemplates(currentTemplateField, templates);
     renderTemplateList();
     templateSelect.value = newIndex;
-    templateText.value = '';
+    templateSelect.dispatchEvent(new Event('change'));
   });
 
   templateDeleteBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- ensure template modal repopulates input with saved text for consistent layout

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_688e681ea350832eaeb7b6724c592b6b