### PR TITLE
Fix template modal resizing

### DIFF
--- a/static/statements.css
+++ b/static/statements.css
@@ -37,3 +37,8 @@ body.statements-bg {
   max-width: 400px;
   width: 100%;
 }
+
+#templateSelect {
+  min-height: 10rem;
+  overflow-y: auto;
+}


### PR DESCRIPTION
## Summary
- keep template modal list at constant height to avoid content jumps

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688e6a393500832e9004c3c7b65cbd33