### PR TITLE
Replace account and status columns with bank in statements list

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -196,11 +196,10 @@ def list_statements_meta(request):
         payload = s.data or {}
         data.append({
             'id': s.id,
-            'account_number': payload.get('account', s.account.number if s.account else ''),
             'owner': payload.get('fio', s.account.user.username if s.account and s.account.user else ''),
             'period_start': s.period_start.isoformat(),
             'period_end': s.period_end.isoformat(),
-            'status': payload.get('status'),
+            'bank': payload.get('bank', 'BSPB'),
             'generated_at': s.created_at.isoformat(),
         })
     return JsonResponse(data, safe=False)

--- a/static/ui.js
+++ b/static/ui.js
@@ -178,10 +178,9 @@
         const created = new Date(st.generated_at).toLocaleString('ru-RU');
         tr.innerHTML =
           `<td>${st.id}</td>` +
-          `<td>${st.account_number}</td>` +
           `<td>${st.owner || ''}</td>` +
           `<td>${period}</td>` +
-          `<td>${st.status || 'сгенерирована'}</td>` +
+          `<td>${st.bank || ''}</td>` +
           `<td>${created}</td>` +
           `<td><a class=\"btn btn-sm btn-outline-secondary\" href=\"/statement/${st.id}.pdf\" target=\"_blank\">PDF</a></td>`;
         tr.addEventListener('click', () => loadStatement(st.id));

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,16 +19,15 @@
       </div>
     </div>
     <div class="mb-3">
-      <input id="searchInput" class="form-control" placeholder="Поиск по счёту или ФИО">
+      <input id="searchInput" class="form-control" placeholder="Поиск по ФИО или банку">
     </div>
     <table class="table table-sm" id="statementsTable">
       <thead>
         <tr>
           <th>ID</th>
-          <th>Счёт</th>
           <th>Владелец</th>
           <th>Период</th>
-          <th>Статус</th>
+          <th>Банк</th>
           <th>Создано</th>
           <th>Действия</th>
         </tr>


### PR DESCRIPTION
## Summary
- Show bank name in statements dashboard instead of account and status
- Adjust client-side table rendering for new bank column
- Expose bank in statements list API

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688e6ac58e50832e9c628c57594c254d