### PR TITLE
style: enlarge template modal

### DIFF
--- a/static/statements.css
+++ b/static/statements.css
@@ -33,9 +33,18 @@ body.statements-bg {
 
 .modal-content {
   background: #fff;
-  border-radius: 0.5rem;
-  max-width: 400px;
+  border-radius: 0.75rem;
+  max-width: 500px;
   width: 100%;
+  border: 1px solid #dee2e6;
+  box-shadow: 0 0.75rem 1.5rem rgba(0, 0, 0, 0.1);
+}
+
+#templateTitle {
+  font-weight: 600;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #dee2e6;
 }
 
 #templateSelect {

--- a/templates/index.html
+++ b/templates/index.html
@@ -106,7 +106,7 @@
 
 <div id="templateModal" class="modal d-none">
   <div class="modal-dialog">
-    <div class="modal-content p-3">
+    <div class="modal-content p-4">
       <h5 id="templateTitle" class="mb-2">Шаблоны</h5>
       <select id="templateSelect" class="form-select mb-2" size="5"></select>
       <input type="text" id="templateText" class="form-control mb-2" placeholder="Новый шаблон">


### PR DESCRIPTION
## Summary
- expand templates modal width and padding for a roomier layout
- add subtle border and shadow styling for a cleaner look

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_688e76a93d2c832e950f9206674a8a6f