### PR TITLE
Display subscription expiry date and restrict PDF generation after expiration

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -120,6 +120,10 @@ def panel(request):
 @require_POST
 @login_required
 def statement_custom(request):
+    profile, _ = UserProfile.objects.get_or_create(user=request.user)
+    if not profile.has_active_subscription():
+        return JsonResponse({'error': 'Subscription expired'}, status=403)
+
     try:
         payload = json.loads(request.body)
     except json.JSONDecodeError:

--- a/templates/panel.html
+++ b/templates/panel.html
@@ -55,7 +55,7 @@
                 <form method="post" class="d-flex align-items-center">
                   {% csrf_token %}
                   <input type="hidden" name="user_id" value="{{ u.id }}">
-                  <input type="date" name="subscription_end" value="{{ u.profile.subscription_end|default:'' }}" class="form-control form-control-sm me-2">
+                  <input type="date" name="subscription_end" value="{{ u.profile.subscription_end|date:'Y-m-d' }}" class="form-control form-control-sm me-2">
                   <button type="submit" name="update_subscription" class="btn btn-outline-secondary btn-sm">Сохранить</button>
                 </form>
               </td>


### PR DESCRIPTION
## Summary
- Format subscription end date in admin panel so saved values show in the date picker
- Prevent users with expired subscriptions from generating new statement PDFs

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68927062c334832ea2e2c04a8464e112